### PR TITLE
Use unicode symbols for sensitivity analysis

### DIFF
--- a/ModelCalibration/HybridModelCalibration.ipynb
+++ b/ModelCalibration/HybridModelCalibration.ipynb
@@ -429,7 +429,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.2",
+   "display_name": "Julia 1.10.4",
    "language": "julia",
    "name": "julia-1.10"
   },
@@ -437,7 +437,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.10.2"
+   "version": "1.10.4"
   }
  },
  "nbformat": 4,

--- a/ModelCalibration/RatesModelCalibration.ipynb
+++ b/ModelCalibration/RatesModelCalibration.ipynb
@@ -245,7 +245,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We discuss the sensitivity analysis for the model parameters individually."
+    "We discuss the sensitivity analysis for the model parameters individually.\n",
+    "\n",
+    "As a preceding step, we specify our notation of x- and y-labels in above sensitivity plot.\n",
+    "\n",
+    "  - Model input benchmark time parameters are δ_1, δ_2 and δ_3. These parameters are set to 1 year, 10 years and 20 years. The choice is relevant for the interpretation of displayed sensitivities.\n",
+    "  - Model input mean reversion parameters are χ_1, χ_2 and χ_3.\n",
+    "  - Model input volatility parameters are σ_1, σ_2 and σ_3. Recall, that we use `DiffFusion.ZeroRateScaling`. This setting is also relevant for the interpretation of displayed results.\n",
+    "  - Model input correlation parameters are Γ_1,2, Γ_2,3, and Γ_2,3.\n",
+    "\n",
+    "  - Model-implied zero rate volatilities are denoted as σ(1y) to σ(20y). The term 1y to 20y denotes the term of the zero rate.\n",
+    "  - Model-implied correlations between zero rates are denoted as Γ(1y, 2y) to Γ(15y, 20y). Again, the term 1y to 20y denotes the term of the zero rate."
    ]
   },
   {
@@ -254,14 +264,12 @@
    "source": [
     "### Volatility Parameters\n",
     "\n",
-    "Volatility parameters are denoted as `EUR_f_1` (1-year term), `EUR_f_2` (10-year term), `EUR_f_3` (20-year term).\n",
+    "As expected, we find that sensitivity of reference rate volatilities (1/10/20-year terms) with respect to corresponding model parameters is close to one. This represents a consistency check for our model specification and implementation. Note that the sensitivity of the σ(1y) volatility w.r.t. the σ_1 parameter is slightly below 1. This is explained by the impact of mean reversion over the modelled 1-month return horizon.\n",
     "\n",
-    "As expected, we find that sensitivity of reference rate volatilities (1/10/20-year terms) with respect to corresponding model parameters is close to one. This represents a consistency check for our model specification and implementation. Note that the sensitivity of the `EUR_1` volatility w.r.t. the `EUR_f_1` parameter is slightly below 1. This is explained by the impact of mean reversion over the modelled 1-month return horizon.\n",
-    "\n",
-    "It is remarkable to see that the `EUR_f_2` and `EUR_f_3` have considerable impact on the 2-year and 5-year volatilities with opposing signs. This observation is linked to the fact that the modelled zero rates are *overlapping* rates. Such a behaviour needs to be kept in mind when designing automated calibration methodologies to avoid distorted solutions. The shared impact of `EUR_f_2` and `EUR_f_3` with weights approximately $1/3$ and $2/3$ on the 15-year volatility is more in line with intuition.\n",
+    "It is remarkable to see that the σ_2 and σ_3 have considerable impact on the 2-year and 5-year volatilities with opposing signs. This observation is linked to the fact that the modelled zero rates are *overlapping* rates. Such a behaviour needs to be kept in mind when designing automated calibration methodologies to avoid distorted solutions. The shared impact of σ_2 and σ_3 with weights approximately $1/3$ and $2/3$ on the 15-year volatility is more in line with intuition.\n",
     "\n",
     "\n",
-    "Model-implied correlations are mildly affected by volatility parameters. `EUR_f_2` and `EUR_f_3` volatilities have some impact on 2-year and 5-year correlations, again with opposing signs. Overall, volatility and correlation impacts can reasonably well be disentangled.\n",
+    "Model-implied correlations are mildly affected by volatility parameters. σ_2 and σ_3 volatilities have some impact on 2-year and 5-year correlations, again with opposing signs. Overall, volatility and correlation impacts can reasonably well be disentangled.\n",
     "\n"
    ]
   },
@@ -271,13 +279,11 @@
    "source": [
     "### Correlation Parameters\n",
     "\n",
-    "Correlation parameters are `EUR_f_1__EUR_f_2` (1-year vs. 10-year), `EUR_f_2__EUR_f_3` (10-year vs. 20-year) and `EUR_f_1__EUR_f_3` (1-year vs. 20-year).\n",
-    "\n",
-    "We find again, that the sensitivity of (output correlation) `EUR_1__EUR_20` to (input correlation) `EUR_f_1__EUR_f_3` and `EUR_10__EUR_20` to `EUR_f_2__EUR_f_3` is close to one. This is expected given the chosen benchmark times. The sensitivity of `EUR_1__EUR_10` to `EUR_f_1__EUR_f_2` is considerably below one. This observation is attributed to the interplay with mean reversion.\n",
+    "We find again, that the sensitivity of (output correlation) Γ(1y, 20y) with respect to (input correlation) Γ_1,3 and Γ(10y, 20y) with respect to Γ_2,3 is close to one. This is expected given the chosen benchmark times. The sensitivity of Γ(1y, 10y) with respect to Γ_1,2 is considerably below one. This observation is attributed to the interplay with mean reversion.\n",
     "\n",
     "As expected, other (output) correlations are also impacted by the input correlations. The sensitivity structure is fairly complex. It is advised to be careful when applying automated best-fit calibrations to avoid distorted (or extreme) input correlation parameters.\n",
     "\n",
-    "The `EUR_f_2__EUR_f_3` (10-year vs. 20-year) input correlation also impacts the `EUR_2` and `EUR_5` volatility. This sensitivity can be explained by the nature of modelled overlapping zero rates: If correlation 10-year vs. 20-year increases then forward rate volatility 10-year into 20-year also increases. Given that 10-year and 20-year spot rate volatility are fixed (in the setting of sensitivity calculation), the forward rate volatility increase is offset by the 2-year and 5-year spot rate volatility."
+    "The Γ_2,3 (10-year vs. 20-year) input correlation also impacts the model-implied volatilities σ(2y) and σ(5y). This sensitivity can be explained by the nature of modelled overlapping zero rates: If correlation 10-year vs. 20-year increases then forward rate volatility 10-year into 20-year also increases. Given that 10-year and 20-year spot rate volatility are fixed (in the setting of sensitivity calculation), the forward rate volatility increase is offset by the 2-year and 5-year spot rate volatility."
    ]
   },
   {
@@ -286,11 +292,9 @@
    "source": [
     "### Mean Reversion Parameters\n",
     "\n",
-    "Mean reversion parameters are denoted as `chi_1`, `chi_2` and `chi_3`.\n",
+    "We see that mean reversion particularly impacts volatilities for 2-year and 5-year term. This impact is particularly pronounced for the first mean reversion parameter χ_1. The first mean reversion parameter is the smallest mean reversion parameter and typically close to zero. Other mean reversion parameters are typically considerably larger. A change in the smallest mean reversion parameter has a large impact on the overall mean reversion in the model. Thus, it is expected that it also impacts volatility most. However, χ_1 is intentionally small to model parallel shifts of the yield curve. As a consequence, there is not too much degree of freedom in setting this parameter.\n",
     "\n",
-    "We see that mean reversion particularly impacts volatilities for 2-year and 5-year term. This impact is particularly pronounced for the first mean reversion parameter `chi_1`. The first mean reversion parameter is the smallest mean reversion parameter and typically close to zero. Other mean reversion parameters are typically considerably larger. A change in the smallest mean reversion parameter has a large impact on the overall mean reversion in the model. Thus, it is expected that it also impacts volatility most. However, `chi_1` is intentionally small to model parallel shifts of the yield curve. As a consequence, there is not too much degree of freedom in setting this parameter.\n",
-    "\n",
-    "The parameters `chi_2` and `chi_3` also impact volatilities for 2-year and 5-year term though to a lesser degree. But we can use these parameters to control the slope of volatilities depending on rate term.\n",
+    "The parameters χ_2 and χ_3 also impact volatilities for 2-year and 5-year term though to a lesser degree. But we can use these parameters to control the slope of volatilities depending on rate term.\n",
     "\n",
     "Mean reversion also has a considerable impact on correlations. An increase in mean reversion also increases de-correlation. This needs to be kept in mind when using mean reversion to control volatilities. There are side effects to the correlation structure."
    ]
@@ -300,8 +304,6 @@
    "metadata": {},
    "source": [
     "### Benchmark Time Parameters\n",
-    "\n",
-    "Benchmark time parameters are `delta_1`, `delta_2` and `delta_3`.\n",
     "\n",
     "The choice of benchmark times also impacts volatilities and correlations. This impact stems from the fact that the benchmark times specify the terms on the yield curve which are explicitly modelled. A change in benchmark times means a change in *interpolation* of model properties.\n",
     "\n",
@@ -316,11 +318,6 @@
     "\n",
     "Model calibration procedures can be automated. Given the complex sensitivity structure, a brute-force least-squares optimisation is likely not the method of choice. Instead, calibration objectives and corresponding model parameters should be aligned based on thorough considerations and well understood model properties."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/ModelCalibration/utils.jl
+++ b/ModelCalibration/utils.jl
@@ -620,31 +620,32 @@ function plot_model_sensitivities(model_params, scaling_type = DiffFusion.ZeroRa
     show(stdout, "text/plain", round.(J, digits=4))
     #
     x_labels = [
-        "delta_1",
-        "delta_2",
-        "delta_3",
+        "δ_1",
+        "δ_2",
+        "δ_3",
         #
-        "chi_1",
-        "chi_2",
-        "chi_3",
+        "χ_1",
+        "χ_2",
+        "χ_3",
         #
-        "EUR_f_1",
-        "EUR_f_2",
-        "EUR_f_3",
+        "σ_1",
+        "σ_2",
+        "σ_3",
         #
-        "EUR_f_1__EUR_f_2",
-        "EUR_f_2__EUR_f_3",
-        "EUR_f_1__EUR_f_3",
+        "Γ_1,2",
+        "Γ_2,3",
+        "Γ_1,3",
     ]
     #
     rf_eur = [ ("EUR", 1), ("EUR", 2), ("EUR", 5), ("EUR", 10), ("EUR", 15), ("EUR", 20),]
     y_labels_vol = [
-        l[1] * "_" * string(l[2])
+        "σ(" * string(l[2]) * "y)"
         for l in rf_eur
     ]
     idx = make_index_list(rf_eur)
     y_labels_corr = [
-        l[1] * "_" * string(l[2]) * "__" * l[3] * "_" * string(l[4])
+        # l[1] * "_" * string(l[2]) * "__" * l[3] * "_" * string(l[4])
+        "Γ(" * string(l[2]) * "y, " * string(l[4]) * "y)"
         for l in idx
     ]
     y_labels = vcat(y_labels_vol, y_labels_corr)


### PR DESCRIPTION
This PR aims at improving readability for the ModelCalibration example. We use unicode symbols for model parameters and model-implied volatilities and correlations.